### PR TITLE
03/03: add mbasta solution

### DIFF
--- a/03/solutions/03-strip-prefix/src/lib.rs
+++ b/03/solutions/03-strip-prefix/src/lib.rs
@@ -1,1 +1,2 @@
 #![allow(dead_code)]
+mod mbasta;

--- a/03/solutions/03-strip-prefix/src/mbasta.rs
+++ b/03/solutions/03-strip-prefix/src/mbasta.rs
@@ -1,0 +1,58 @@
+//! Run this file with `cargo test --test 02_strip_prefix`.
+
+// TODO: Implement a function called `strip_prefix`, which will take two strings (`needle` and `prefix`).
+// It will return a substring of `needle` starting at the first character that is not contained
+// in `prefix`.
+// See tests for examples. Take a look at the `strip_prefix_lifetime_check` test!
+//
+// Hint: you can use `string.chars()` for iterating the Unicode characters of a string.
+
+use std::collections::HashSet;
+
+fn strip_prefix<'a, 'b>(needle: &'a str, prefix: &'b str) -> &'a str {
+    let prefix: HashSet<char> = prefix.chars().collect();
+    // needle.chars().enumerate() counts the nuber of iterations, but because each Char can have a
+    // different size in bytes. The index of a Char in the string slice doesn't match the iteration count.
+    // `char_indices` returns for each Char its correct index in the string slice.
+    for (idx, char) in needle.char_indices() {
+        if !prefix.contains(&char) {
+            return &needle[idx..];
+        }
+    }
+    ""
+}
+
+/// Below you can find a set of unit tests.
+#[cfg(test)]
+mod tests {
+    use super::strip_prefix;
+
+    #[test]
+    fn strip_prefix_basic() {
+        assert_eq!(strip_prefix("foobar", "of"), "bar");
+    }
+
+    #[test]
+    fn strip_prefix_full_result() {
+        assert_eq!(strip_prefix("foobar", "x"), "foobar");
+    }
+
+    #[test]
+    fn strip_prefix_empty_result() {
+        assert_eq!(strip_prefix("foobar", "fbaro"), "");
+    }
+
+    #[test]
+    fn strip_prefix_unicode() {
+        assert_eq!(strip_prefix("čaukymňauky", "čaukym"), "ňauky");
+    }
+
+    #[test]
+    fn strip_prefix_lifetime_check() {
+        let needle = "foobar";
+        let prefix = String::from("f");
+        let result = strip_prefix(needle, &prefix);
+        drop(prefix);
+        assert_eq!(result, "oobar");
+    }
+}


### PR DESCRIPTION
> Hint: you can use `string.chars()` for iterating the Unicode characters of a string.

This hint was a bit misleading. Using `Char`s is fine, but not the method `chars` IMO. There's this method `char_indices` which tracks the bytes for each `Char`, giving in the end an index that can be safely used for subslicing. Surely, that tracking could be done manually, but is not very pretty.

I also used a `HashSet` to avoid iterating over the whole `prefix` in each iteration of `needle`'s elements. That would be O(n^2) in the worst case.

I tried using `needle.char_indices().skip_while...` in order to make it "prettier", but I need the index counter outside of the predicate argument, which wouldn't be prettier if I had implemented it.

Lastly, I believe subslicing is a dangerous practice and should be used with caution. This exercise requires subslicing because the return type is expected to be a string slice (and not an `Option`/`Result`.