### PR TITLE
04/solutions/01: Add ifraixedes implementation

### DIFF
--- a/04/solutions/01-shape-interface/src/ifraixedes.rs
+++ b/04/solutions/01-shape-interface/src/ifraixedes.rs
@@ -1,0 +1,136 @@
+//! Run this file with `cargo test --test 01_shape`.
+
+//! TODO: Create a trait `Shape` with methods for calculating the area and perimeter of a geometrical
+//! object. Then create two simple geometrical objects (`Rectangle` and `Circle`) and implement
+//! the `Shape` trait for both of them.
+
+use std::f64::consts::PI;
+
+trait Shape {
+    fn area(&self) -> f64;
+    fn perimeter(&self) -> f64;
+}
+
+struct Circle {
+    radius: f64,
+}
+
+impl Circle {
+    fn new(radius: f64) -> Self {
+        Self { radius }
+    }
+}
+
+impl Shape for Circle {
+    fn area(&self) -> f64 {
+        PI * self.radius.powi(2)
+    }
+
+    fn perimeter(&self) -> f64 {
+        2.0 * PI * self.radius
+    }
+}
+
+struct Rectangle {
+    side_a: f64,
+    side_b: f64,
+}
+
+impl Rectangle {
+    fn new(side_a: f64, side_b: f64) -> Self {
+        Self { side_a, side_b }
+    }
+}
+
+impl Shape for Rectangle {
+    fn area(&self) -> f64 {
+        self.side_a * self.side_b
+    }
+
+    fn perimeter(&self) -> f64 {
+        2.0 * (self.side_a + self.side_b)
+    }
+}
+
+/// Below you can find a set of unit tests.
+#[cfg(test)]
+mod tests {
+    use super::{Circle, Rectangle, Shape};
+    use std::f64::consts::PI;
+
+    #[test]
+    fn rectangle1() {
+        let rectangle = Rectangle::new(5.0, 3.0);
+        assert_almost_eq(rectangle.area(), 15.0);
+        assert_almost_eq(rectangle.perimeter(), 16.0);
+    }
+
+    #[test]
+    fn rectangle2() {
+        let rectangle = Rectangle::new(0.3, 1982.3);
+        assert_almost_eq(rectangle.area(), 594.69);
+        assert_almost_eq(rectangle.perimeter(), 3965.2);
+    }
+
+    #[test]
+    fn rectangle3() {
+        let rectangle = Rectangle::new(0.0, 1.0);
+        assert_almost_eq(rectangle.area(), 0.0);
+        assert_almost_eq(rectangle.perimeter(), 2.0);
+    }
+
+    #[test]
+    fn circle1() {
+        let rectangle = Circle::new(5.0);
+        assert_almost_eq(rectangle.area(), 25.0 * PI);
+        assert_almost_eq(rectangle.perimeter(), 10.0 * PI);
+    }
+
+    #[test]
+    fn circle2() {
+        let rectangle = Circle::new(122038.12);
+        assert_almost_eq(rectangle.area(), 46788690454.10);
+        assert_almost_eq(rectangle.perimeter(), 766788.122);
+    }
+
+    #[test]
+    fn circle3() {
+        let rectangle = Circle::new(0.0);
+        assert_almost_eq(rectangle.area(), 0.0);
+        assert_almost_eq(rectangle.perimeter(), 0.0);
+    }
+
+    #[test]
+    fn test_implements_trait() {
+        fn take_shape<T: Shape>(_: T) {}
+
+        take_shape(Circle::new(1.0));
+        take_shape(Rectangle::new(1.0, 1.0));
+    }
+
+    #[test]
+    fn circle_big_number() {
+        use std::f64::MAX;
+
+        let circle = Circle::new(MAX);
+        assert!(circle.area().is_infinite());
+        assert!(circle.perimeter().is_infinite());
+    }
+
+    #[test]
+    fn rectangle_big_number() {
+        use std::f64::MAX;
+
+        let rectangle = Rectangle::new(MAX, 1.0);
+        assert_almost_eq(rectangle.area(), MAX);
+        assert!(rectangle.perimeter().is_infinite());
+    }
+
+    #[track_caller]
+    fn assert_almost_eq(value: f64, expected: f64) {
+        assert!(
+            (value - expected).abs() < 0.01,
+            "{value} does not equal {expected}"
+        );
+    }
+}

--- a/04/solutions/01-shape-interface/src/lib.rs
+++ b/04/solutions/01-shape-interface/src/lib.rs
@@ -1,2 +1,4 @@
 #![allow(dead_code)]
+
 mod frankparejo;
+mod ifraixedes;


### PR DESCRIPTION
Add my implementation and a couple of test cases to see show what's happening with floats in Rust when the value exceed the precision which is a different behavior than integers.