### PR TITLE
.github/workflows: Bump Rust version

### DIFF
--- a/.github/workflows/pr-solutions.yml
+++ b/.github/workflows/pr-solutions.yml
@@ -13,7 +13,7 @@ permissions:
   contents: read
 
 env:
-  RUST_VERSION: "1.85.0"
+  RUST_VERSION: "1.97.0"
 
 jobs:
   detect:


### PR DESCRIPTION
Use the last stable Rust version for the CI pipeline.